### PR TITLE
Add beauty rendering pipeline and controls

### DIFF
--- a/application/resources/src/main/res/values/strings.xml
+++ b/application/resources/src/main/res/values/strings.xml
@@ -1338,4 +1338,12 @@
     <string name="queue_format">Queue format</string>
     <string name="queue_format_short_desc">Queue position</string>
     <string name="queue_format_long_desc">Queue position / Queue size</string>
+    <string name="beauty_switch">Beauty mode</string>
+    <string name="beauty_section_face">Face adjustments</string>
+    <string name="beauty_section_filters">Filters</string>
+    <string name="beauty_filter_none">Original</string>
+    <string name="beauty_filter_warm">Warm glow</string>
+    <string name="beauty_filter_film">Cinematic</string>
+    <string name="beauty_filter_retro">Retro</string>
+    <string name="beauty_panel_button">Beauty</string>
 </resources>

--- a/application/vlc-android/res/drawable/ic_beauty.xml
+++ b/application/vlc-android/res/drawable/ic_beauty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2c-1.93,0 -3.68,0.78 -4.95,2.05C5.78,5.32 5,7.07 5,9c0,2.8 1.94,5.97 5.78,9.53 0.68,0.61 1.75,0.61 2.43,0C17.06,14.97 19,11.8 19,9c0,-1.93 -0.78,-3.68 -2.05,-4.95C15.68,2.78 13.93,2 12,2zM12,13c-2.21,0 -4,-1.79 -4,-4s1.79,-4 4,-4 4,1.79 4,4 -1.79,4 -4,4z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,7.5A1.5,1.5 0 0 0 10.5,9 1.5,1.5 0 0 0 12,10.5 1.5,1.5 0 0 0 13.5,9 1.5,1.5 0 0 0 12,7.5z" />
+</vector>

--- a/application/vlc-android/res/drawable/rounded_panel_background.xml
+++ b/application/vlc-android/res/drawable/rounded_panel_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#B3000000" />
+    <corners android:radius="12dp" />
+</shape>

--- a/application/vlc-android/res/layout/player.xml
+++ b/application/vlc-android/res/layout/player.xml
@@ -14,7 +14,7 @@
      (which requires the surface not be centered), while keeping the result centered
     -->
 
-    <org.videolan.libvlc.util.VLCVideoLayout
+    <org.videolan.vlc.gui.beauty.BeautyVideoLayout
             android:id="@+id/video_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -97,6 +97,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical|end"/>
+
+        <androidx.appcompat.widget.ViewStubCompat
+                android:id="@+id/player_beauty_stub"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|end"
+                android:layout="@layout/player_beauty_panel" />
 
         <androidx.appcompat.widget.ViewStubCompat
                 android:id="@+id/player_hud_right_stub"

--- a/application/vlc-android/res/layout/player_beauty_panel.xml
+++ b/application/vlc-android/res/layout/player_beauty_panel.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/beauty_panel_root"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="center_vertical|end"
+    android:background="@drawable/rounded_panel_background"
+    android:padding="16dp"
+    android:visibility="gone">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:dividerPadding="8dp">
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/beauty_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/beauty_switch"
+            android:checked="true" />
+
+        <TextView
+            style="@style/TextAppearance.MaterialComponents.Body2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/beauty_section_face" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/beauty_slider_smooth"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            app:labelBehavior="gone" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/beauty_slider_face"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            app:labelBehavior="gone" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/beauty_slider_eye"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            app:labelBehavior="gone" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/beauty_slider_nose"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            app:labelBehavior="gone" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/beauty_slider_mouth"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            app:labelBehavior="gone" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="12dp" />
+
+        <TextView
+            style="@style/TextAppearance.MaterialComponents.Body2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/beauty_section_filters" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/beauty_slider_filter_intensity"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            app:labelBehavior="gone" />
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/beauty_filter_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:singleSelection="true"
+            app:selectionRequired="true"
+            app:chipSpacing="8dp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/application/vlc-android/res/layout/player_hud.xml
+++ b/application/vlc-android/res/layout/player_hud.xml
@@ -501,6 +501,24 @@
                     vlc:srcCompat="@drawable/ic_player_ratio" />
 
             <ImageView
+                    android:id="@+id/player_overlay_beauty"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/small_margins_sides"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:contentDescription="@string/beauty_panel_button"
+                    android:focusable="true"
+                    android:onClick="@{(v) -> player.toggleBeautyPanel()}"
+                    android:scaleType="center"
+                    tools:visibility="visible"
+                    vlc:layout_constraintBottom_toBottomOf="@+id/player_overlay_play"
+                    vlc:layout_constraintEnd_toStartOf="@+id/player_overlay_adv_function"
+                    vlc:layout_constraintStart_toEndOf="@+id/player_resize"
+                    vlc:layout_constraintTop_toTopOf="@+id/player_overlay_play"
+                    vlc:srcCompat="@drawable/ic_beauty" />
+
+            <ImageView
                     android:id="@+id/player_overlay_adv_function"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -514,7 +532,7 @@
                     tools:visibility="visible"
                     vlc:layout_constraintBottom_toBottomOf="@+id/player_overlay_play"
                     vlc:layout_constraintEnd_toEndOf="parent"
-                    vlc:layout_constraintStart_toEndOf="@+id/player_resize"
+                    vlc:layout_constraintStart_toEndOf="@+id/player_overlay_beauty"
                     vlc:layout_constraintTop_toTopOf="@+id/player_overlay_play"
                     vlc:srcCompat="@drawable/ic_player_more" />
 

--- a/application/vlc-android/res/layout/player_remote_control.xml
+++ b/application/vlc-android/res/layout/player_remote_control.xml
@@ -9,7 +9,7 @@
      (which requires the surface not be centered), while keeping the result centered
     -->
 
-    <org.videolan.libvlc.util.VLCVideoLayout
+    <org.videolan.vlc.gui.beauty.BeautyVideoLayout
             android:id="@+id/video_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -68,6 +68,15 @@
                 android:layout_marginRight="@dimen/default_margin"
                 android:layout_marginBottom="@dimen/default_margin"
                 android:layout="@layout/player_overlay_settings" />
+
+        <androidx.appcompat.widget.ViewStubCompat
+                android:id="@+id/player_beauty_stub"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|end"
+                android:layout_marginEnd="@dimen/default_margin"
+                android:layout_marginBottom="@dimen/default_margin"
+                android:layout="@layout/player_beauty_panel" />
 
         <androidx.appcompat.widget.ViewStubCompat
                 android:id="@+id/player_seek_stub"

--- a/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyConfig.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyConfig.kt
@@ -1,0 +1,76 @@
+package org.videolan.vlc.gui.beauty
+
+import androidx.annotation.StringRes
+import org.videolan.vlc.R
+
+/**
+ * Defines the runtime configurable beauty parameters that can be
+ * controlled from the UI. All values are expressed between 0f and 1f.
+ */
+data class BeautyConfig(
+    val skinSmoothing: Float = 0.35f,
+    val faceSlimming: Float = 0.2f,
+    val eyeEnlarge: Float = 0.18f,
+    val noseRefine: Float = 0.1f,
+    val mouthAdjust: Float = 0.05f,
+    val filterIntensity: Float = 0.6f,
+    val filterId: String = BeautyFilterPreset.NONE.id,
+)
+
+/**
+ * Color grading presets that can be stacked on top of the beauty shader.
+ */
+data class BeautyFilterPreset(
+    val id: String,
+    @StringRes val titleRes: Int,
+    val colorMatrix: FloatArray,
+    val strength: Float = 1.0f
+) {
+    companion object {
+        const val MATRIX_LENGTH = 9
+        val NONE = BeautyFilterPreset(
+            id = "none",
+            titleRes = R.string.beauty_filter_none,
+            colorMatrix = floatArrayOf(
+                1f, 0f, 0f,
+                0f, 1f, 0f,
+                0f, 0f, 1f
+            ),
+            strength = 0f
+        )
+
+        fun presets(): List<BeautyFilterPreset> = listOf(
+            NONE,
+            BeautyFilterPreset(
+                id = "warm_glow",
+                titleRes = R.string.beauty_filter_warm,
+                colorMatrix = floatArrayOf(
+                    1.12f, -0.05f, 0.03f,
+                    0.02f, 1.05f, 0.01f,
+                    -0.04f, 0f, 1.03f
+                ),
+                strength = 0.85f
+            ),
+            BeautyFilterPreset(
+                id = "film",
+                titleRes = R.string.beauty_filter_film,
+                colorMatrix = floatArrayOf(
+                    1.05f, 0.02f, -0.08f,
+                    0.02f, 0.95f, -0.02f,
+                    0.06f, 0.04f, 0.92f
+                ),
+                strength = 0.9f
+            ),
+            BeautyFilterPreset(
+                id = "retro",
+                titleRes = R.string.beauty_filter_retro,
+                colorMatrix = floatArrayOf(
+                    0.85f, 0.1f, 0.05f,
+                    0.04f, 0.9f, 0.02f,
+                    0.04f, 0.08f, 0.86f
+                ),
+                strength = 0.75f
+            )
+        )
+    }
+}

--- a/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyManager.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyManager.kt
@@ -1,0 +1,128 @@
+package org.videolan.vlc.gui.beauty
+
+import android.view.Surface
+import android.view.SurfaceView
+import android.view.View
+import org.videolan.libvlc.MediaPlayer
+import org.videolan.libvlc.util.DisplayManager
+
+/**
+ * Coordinates VLC's decoded frames with the OpenGL renderer. It is responsible
+ * for swapping VLC's default surfaces with the GL texture once it is ready,
+ * managing lifecycle events and dispatching configuration changes to the
+ * renderer.
+ */
+class BeautyManager(
+    private val layout: BeautyVideoLayout
+) {
+
+    private val renderer = BeautyRenderer()
+    private var renderSurface: Surface? = null
+    private var mediaPlayer: MediaPlayer? = null
+    private var displayManager: DisplayManager? = null
+    private var subtitlesSurface: Surface? = null
+
+    private var config: BeautyConfig = BeautyConfig()
+    private var filterPreset: BeautyFilterPreset = BeautyFilterPreset.NONE
+
+    private var pendingAttach = false
+
+    init {
+        layout.setRenderer(renderer)
+        renderer.setOnFrameRequested { layout.requestRender() }
+        renderer.setOnSurfaceTextureReady { surfaceTexture ->
+            renderSurface?.release()
+            renderSurface = Surface(surfaceTexture)
+            bindIfPossible()
+        }
+        renderer.setOnSizeChanged { _, _ ->
+            // Placeholder for dynamic adjustments if needed later.
+        }
+    }
+
+    fun onResume() {
+        layout.onRendererResume()
+    }
+
+    fun onPause() {
+        layout.onRendererPause()
+    }
+
+    fun attachToPlayer(mediaPlayer: MediaPlayer, displayManager: DisplayManager) {
+        this.mediaPlayer = mediaPlayer
+        this.displayManager = displayManager
+        pendingAttach = true
+        bindIfPossible()
+    }
+
+    fun detachFromPlayer() {
+        pendingAttach = false
+        mediaPlayer?.vlcVout?.detachViews()
+        mediaPlayer = null
+        displayManager = null
+        renderSurface?.release()
+        renderSurface = null
+        subtitlesSurface = null
+        layout.resetVideoSurfaceVisibility()
+    }
+
+    fun destroy() {
+        detachFromPlayer()
+        layout.queueEvent { renderer.release() }
+    }
+
+    fun setBeautyEnabled(enabled: Boolean) {
+        layout.queueEvent { renderer.setBeautyEnabled(enabled) }
+        layout.requestRender()
+    }
+
+    fun updateConfig(block: (BeautyConfig) -> BeautyConfig) {
+        config = block(config)
+        layout.queueEvent { renderer.updateConfig(config) }
+        selectFilter(filterPreset)
+        layout.requestRender()
+    }
+
+    fun selectFilter(preset: BeautyFilterPreset) {
+        filterPreset = preset
+        config = config.copy(filterId = preset.id)
+        layout.queueEvent {
+            renderer.setFilter(preset.colorMatrix, preset.strength)
+            renderer.updateConfig(config)
+        }
+        layout.requestRender()
+    }
+
+    fun currentConfig(): BeautyConfig = config
+
+    fun currentFilter(): BeautyFilterPreset = filterPreset
+
+    private fun bindIfPossible() {
+        if (!pendingAttach) return
+        val surface = renderSurface ?: return
+        val player = mediaPlayer ?: return
+        val manager = displayManager ?: return
+
+        val vout = player.vlcVout
+        vout.detachViews()
+        vout.setVideoSurface(surface, null)
+        val subtitleView = layout.getSubtitleSurfaceView()
+        subtitlesSurface = subtitleView?.holder?.surface
+        val subtitleHolder = subtitleView?.holder
+        if (subtitlesSurface != null && subtitleHolder != null) {
+            vout.setSubtitlesSurface(subtitlesSurface, subtitleHolder)
+        }
+        vout.attachViews(layout, manager, true, false)
+        hideOriginalVideoSurface()
+        pendingAttach = false
+    }
+
+    private fun hideOriginalVideoSurface() {
+        layout.getVideoSurfaceView()?.let { view ->
+            view.visibility = View.INVISIBLE
+            if (view is SurfaceView) {
+                view.holder.setFixedSize(view.width, view.height)
+            }
+        }
+    }
+}

--- a/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyRenderer.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyRenderer.kt
@@ -1,0 +1,379 @@
+package org.videolan.vlc.gui.beauty
+
+import android.graphics.SurfaceTexture
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.GLSurfaceView
+import androidx.annotation.GuardedBy
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.max
+
+/**
+ * OpenGL renderer responsible for drawing VLC's decoded frames on top of our
+ * post-processing pipeline. The shader is intentionally simple – it blends a
+ * light weight smoothing pass with a couple of warping functions and an
+ * optional color matrix.
+ */
+class BeautyRenderer : GLSurfaceView.Renderer, SurfaceTexture.OnFrameAvailableListener {
+
+    private val vertexBuffer: FloatBuffer
+    private val textureBuffer: FloatBuffer
+
+    private val texMatrix = FloatArray(16)
+
+    private var program = 0
+    private var positionHandle = 0
+    private var textureHandle = 0
+    private var texMatrixHandle = 0
+    private var smoothingHandle = 0
+    private var faceHandle = 0
+    private var eyeHandle = 0
+    private var noseHandle = 0
+    private var mouthHandle = 0
+    private var enabledHandle = 0
+    private var resolutionHandle = 0
+    private var colorMatrixHandle = 0
+    private var filterIntensityHandle = 0
+
+    private var surfaceTexture: SurfaceTexture? = null
+    private var textureId = 0
+    private var viewportWidth = 0
+    private var viewportHeight = 0
+
+    private var beautyConfig = BeautyConfig()
+    private var beautyEnabled = true
+    private val currentFilterMatrix = FloatArray(BeautyFilterPreset.MATRIX_LENGTH)
+    private var currentFilterBaseStrength = 0f
+    private var currentFilterStrength = 0f
+
+    private val frameAvailable = AtomicBoolean(false)
+
+    private val callbacksLock = Any()
+    @GuardedBy("callbacksLock")
+    private var surfaceReadyCallback: ((SurfaceTexture) -> Unit)? = null
+    @GuardedBy("callbacksLock")
+    private var sizeChangedCallback: ((Int, Int) -> Unit)? = null
+    @GuardedBy("callbacksLock")
+    private var frameCallback: (() -> Unit)? = null
+
+    init {
+        val vertexData = floatArrayOf(
+            -1f, -1f,
+             1f, -1f,
+            -1f,  1f,
+             1f,  1f,
+        )
+        vertexBuffer = ByteBuffer.allocateDirect(vertexData.size * FLOAT_SIZE_BYTES)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer()
+            .put(vertexData)
+        vertexBuffer.position(0)
+
+        val textureData = floatArrayOf(
+            0f, 1f,
+            1f, 1f,
+            0f, 0f,
+            1f, 0f,
+        )
+        textureBuffer = ByteBuffer.allocateDirect(textureData.size * FLOAT_SIZE_BYTES)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer()
+            .put(textureData)
+        textureBuffer.position(0)
+
+        updateConfig(beautyConfig)
+        setFilter(BeautyFilterPreset.NONE.colorMatrix, 0f)
+    }
+
+    fun setOnSurfaceTextureReady(listener: (SurfaceTexture) -> Unit) {
+        synchronized(callbacksLock) {
+            surfaceReadyCallback = listener
+            surfaceTexture?.let(listener)
+        }
+    }
+
+    fun setOnSizeChanged(listener: (Int, Int) -> Unit) {
+        synchronized(callbacksLock) {
+            sizeChangedCallback = listener
+            if (viewportWidth > 0 && viewportHeight > 0) {
+                listener(viewportWidth, viewportHeight)
+            }
+        }
+    }
+
+    fun setOnFrameRequested(listener: () -> Unit) {
+        synchronized(callbacksLock) {
+            frameCallback = listener
+        }
+    }
+
+    fun setBeautyEnabled(enabled: Boolean) {
+        beautyEnabled = enabled
+    }
+
+    fun updateConfig(config: BeautyConfig) {
+        beautyConfig = config
+        updateFilterIntensity()
+    }
+
+    fun setFilter(matrix: FloatArray, baseIntensity: Float) {
+        require(matrix.size == BeautyFilterPreset.MATRIX_LENGTH)
+        System.arraycopy(matrix, 0, currentFilterMatrix, 0, matrix.size)
+        currentFilterBaseStrength = max(0f, baseIntensity)
+        updateFilterIntensity()
+    }
+
+    private fun updateFilterIntensity() {
+        currentFilterStrength = beautyConfig.filterIntensity * currentFilterBaseStrength
+    }
+
+    override fun onSurfaceCreated(gl: javax.microedition.khronos.opengles.GL10?, config: javax.microedition.khronos.egl.EGLConfig?) {
+        program = createProgram(VERTEX_SHADER, FRAGMENT_SHADER)
+        positionHandle = GLES20.glGetAttribLocation(program, "aPosition")
+        textureHandle = GLES20.glGetAttribLocation(program, "aTextureCoord")
+        texMatrixHandle = GLES20.glGetUniformLocation(program, "uTexMatrix")
+        smoothingHandle = GLES20.glGetUniformLocation(program, "uSmooth")
+        faceHandle = GLES20.glGetUniformLocation(program, "uFaceSlim")
+        eyeHandle = GLES20.glGetUniformLocation(program, "uEye")
+        noseHandle = GLES20.glGetUniformLocation(program, "uNose")
+        mouthHandle = GLES20.glGetUniformLocation(program, "uMouth")
+        enabledHandle = GLES20.glGetUniformLocation(program, "uBeautyEnabled")
+        resolutionHandle = GLES20.glGetUniformLocation(program, "uResolution")
+        colorMatrixHandle = GLES20.glGetUniformLocation(program, "uColorMatrix")
+        filterIntensityHandle = GLES20.glGetUniformLocation(program, "uFilterIntensity")
+
+        textureId = generateExternalTexture()
+        surfaceTexture = SurfaceTexture(textureId).apply {
+            setOnFrameAvailableListener(this@BeautyRenderer)
+        }
+        synchronized(callbacksLock) {
+            surfaceReadyCallback?.invoke(surfaceTexture!!)
+        }
+        GLES20.glDisable(GLES20.GL_DEPTH_TEST)
+    }
+
+    override fun onSurfaceChanged(gl: javax.microedition.khronos.opengles.GL10?, width: Int, height: Int) {
+        viewportWidth = width
+        viewportHeight = height
+        synchronized(callbacksLock) {
+            sizeChangedCallback?.invoke(width, height)
+        }
+    }
+
+    override fun onDrawFrame(gl: javax.microedition.khronos.opengles.GL10?) {
+        if (surfaceTexture == null) {
+            GLES20.glClearColor(0f, 0f, 0f, 1f)
+            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+            return
+        }
+        if (frameAvailable.compareAndSet(true, false)) {
+            surfaceTexture?.updateTexImage()
+            surfaceTexture?.getTransformMatrix(texMatrix)
+        }
+
+        GLES20.glViewport(0, 0, viewportWidth, viewportHeight)
+        GLES20.glClearColor(0f, 0f, 0f, 1f)
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+
+        GLES20.glUseProgram(program)
+
+        vertexBuffer.position(0)
+        GLES20.glVertexAttribPointer(positionHandle, 2, GLES20.GL_FLOAT, false, 0, vertexBuffer)
+        GLES20.glEnableVertexAttribArray(positionHandle)
+
+        textureBuffer.position(0)
+        GLES20.glVertexAttribPointer(textureHandle, 2, GLES20.GL_FLOAT, false, 0, textureBuffer)
+        GLES20.glEnableVertexAttribArray(textureHandle)
+
+        GLES20.glUniformMatrix4fv(texMatrixHandle, 1, false, texMatrix, 0)
+        GLES20.glUniform1f(smoothingHandle, beautyConfig.skinSmoothing)
+        GLES20.glUniform1f(faceHandle, beautyConfig.faceSlimming)
+        GLES20.glUniform1f(eyeHandle, beautyConfig.eyeEnlarge)
+        GLES20.glUniform1f(noseHandle, beautyConfig.noseRefine)
+        GLES20.glUniform1f(mouthHandle, beautyConfig.mouthAdjust)
+        GLES20.glUniform1f(enabledHandle, if (beautyEnabled) 1f else 0f)
+        GLES20.glUniform2f(resolutionHandle, viewportWidth.toFloat(), viewportHeight.toFloat())
+        GLES20.glUniformMatrix3fv(colorMatrixHandle, 1, false, currentFilterMatrix, 0)
+        GLES20.glUniform1f(filterIntensityHandle, currentFilterStrength)
+
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+
+        GLES20.glDisableVertexAttribArray(positionHandle)
+        GLES20.glDisableVertexAttribArray(textureHandle)
+    }
+
+    override fun onFrameAvailable(surfaceTexture: SurfaceTexture) {
+        frameAvailable.set(true)
+        synchronized(callbacksLock) {
+            frameCallback?.invoke()
+        }
+    }
+
+    fun release() {
+        surfaceTexture?.setOnFrameAvailableListener(null)
+        surfaceTexture?.release()
+        surfaceTexture = null
+        if (textureId != 0) {
+            val textures = intArrayOf(textureId)
+            GLES20.glDeleteTextures(1, textures, 0)
+            textureId = 0
+        }
+        if (program != 0) {
+            GLES20.glDeleteProgram(program)
+            program = 0
+        }
+    }
+
+    private fun generateExternalTexture(): Int {
+        val texture = IntArray(1)
+        GLES20.glGenTextures(1, texture, 0)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, texture[0])
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+        return texture[0]
+    }
+
+    companion object {
+        private const val FLOAT_SIZE_BYTES = 4
+
+        private const val VERTEX_SHADER = """
+            attribute vec4 aPosition;
+            attribute vec4 aTextureCoord;
+            uniform mat4 uTexMatrix;
+            varying vec2 vTextureCoord;
+            void main() {
+                gl_Position = aPosition;
+                vec4 tex = uTexMatrix * aTextureCoord;
+                vTextureCoord = tex.xy;
+            }
+        """
+
+        private const val FRAGMENT_SHADER = """
+            #extension GL_OES_EGL_image_external : require
+            precision mediump float;
+            varying vec2 vTextureCoord;
+            uniform samplerExternalOES sTexture;
+            uniform float uSmooth;
+            uniform float uFaceSlim;
+            uniform float uEye;
+            uniform float uNose;
+            uniform float uMouth;
+            uniform float uBeautyEnabled;
+            uniform vec2 uResolution;
+            uniform mat3 uColorMatrix;
+            uniform float uFilterIntensity;
+
+            vec2 warpFace(vec2 coord, vec2 center, float radius, float strength) {
+                vec2 dir = coord - center;
+                float dist = length(dir);
+                if (dist < radius) {
+                    float ratio = (radius - dist) / radius;
+                    float scale = 1.0 - strength * ratio * 0.35;
+                    dir *= scale;
+                    return center + dir;
+                }
+                return coord;
+            }
+
+            vec2 warpEye(vec2 coord, vec2 center, float radius, float strength) {
+                vec2 dir = coord - center;
+                float dist = length(dir);
+                if (dist < radius) {
+                    float percent = (radius - dist) / radius;
+                    float scale = 1.0 - strength * percent * 0.45;
+                    dir *= scale;
+                    return center + dir;
+                }
+                return coord;
+            }
+
+            vec2 refineFeature(vec2 coord, vec2 center, float radius, float strength, vec2 direction) {
+                vec2 dir = coord - center;
+                float dist = length(dir);
+                if (dist < radius) {
+                    float percent = (radius - dist) / radius;
+                    return coord - direction * strength * percent * 0.1;
+                }
+                return coord;
+            }
+
+            vec4 sampleSmooth(vec2 coord, vec2 texel, float strength) {
+                vec4 sum = vec4(0.0);
+                sum += texture2D(sTexture, coord + texel * vec2(-2.0, -2.0)) * 0.05;
+                sum += texture2D(sTexture, coord + texel * vec2(-1.0, -1.0)) * 0.09;
+                sum += texture2D(sTexture, coord + texel * vec2(0.0, -1.0)) * 0.12;
+                sum += texture2D(sTexture, coord + texel * vec2(1.0, -1.0)) * 0.09;
+                sum += texture2D(sTexture, coord + texel * vec2(2.0, -2.0)) * 0.05;
+                sum += texture2D(sTexture, coord + texel * vec2(-2.0, 0.0)) * 0.09;
+                sum += texture2D(sTexture, coord) * 0.2;
+                sum += texture2D(sTexture, coord + texel * vec2(2.0, 0.0)) * 0.09;
+                sum += texture2D(sTexture, coord + texel * vec2(-2.0, 2.0)) * 0.05;
+                sum += texture2D(sTexture, coord + texel * vec2(-1.0, 1.0)) * 0.09;
+                sum += texture2D(sTexture, coord + texel * vec2(0.0, 1.0)) * 0.12;
+                sum += texture2D(sTexture, coord + texel * vec2(1.0, 1.0)) * 0.09;
+                sum += texture2D(sTexture, coord + texel * vec2(2.0, 2.0)) * 0.05;
+                vec4 original = texture2D(sTexture, coord);
+                return mix(original, sum, clamp(strength, 0.0, 1.0));
+            }
+
+            void main() {
+                vec2 texel = 1.0 / uResolution;
+                vec2 coord = vTextureCoord;
+                if (uBeautyEnabled > 0.5) {
+                    coord = warpFace(coord, vec2(0.5, 0.65), 0.45, uFaceSlim);
+                    coord = warpEye(coord, vec2(0.35, 0.45), 0.18, uEye);
+                    coord = warpEye(coord, vec2(0.65, 0.45), 0.18, uEye);
+                    coord = refineFeature(coord, vec2(0.5, 0.55), 0.25, uNose, vec2(0.0, 1.0));
+                    coord = refineFeature(coord, vec2(0.5, 0.72), 0.25, uMouth, vec2(0.0, -1.0));
+                }
+                vec4 color = sampleSmooth(coord, texel, uBeautyEnabled * uSmooth);
+                if (uFilterIntensity > 0.0) {
+                    vec3 graded = uColorMatrix * color.rgb;
+                    color.rgb = mix(color.rgb, graded, clamp(uFilterIntensity, 0.0, 1.0));
+                }
+                gl_FragColor = color;
+            }
+        """
+
+        private fun createProgram(vertexShaderCode: String, fragmentShaderCode: String): Int {
+            val vertexShader = loadShader(GLES20.GL_VERTEX_SHADER, vertexShaderCode)
+            val fragmentShader = loadShader(GLES20.GL_FRAGMENT_SHADER, fragmentShaderCode)
+            val program = GLES20.glCreateProgram()
+            GLES20.glAttachShader(program, vertexShader)
+            GLES20.glAttachShader(program, fragmentShader)
+            GLES20.glLinkProgram(program)
+            val status = IntArray(1)
+            GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, status, 0)
+            if (status[0] == 0) {
+                val error = GLES20.glGetProgramInfoLog(program)
+                GLES20.glDeleteProgram(program)
+                throw RuntimeException("Could not link program: $error")
+            }
+            GLES20.glDeleteShader(vertexShader)
+            GLES20.glDeleteShader(fragmentShader)
+            return program
+        }
+
+        private fun loadShader(type: Int, shaderCode: String): Int {
+            val shader = GLES20.glCreateShader(type)
+            GLES20.glShaderSource(shader, shaderCode)
+            GLES20.glCompileShader(shader)
+            val status = IntArray(1)
+            GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, status, 0)
+            if (status[0] == 0) {
+                val error = GLES20.glGetShaderInfoLog(shader)
+                GLES20.glDeleteShader(shader)
+                throw RuntimeException("Could not compile shader: $error")
+            }
+            return shader
+        }
+    }
+}

--- a/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyVideoLayout.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/beauty/BeautyVideoLayout.kt
@@ -1,0 +1,62 @@
+package org.videolan.vlc.gui.beauty
+
+import android.content.Context
+import android.opengl.GLSurfaceView
+import android.util.AttributeSet
+import android.view.SurfaceView
+import android.view.View
+import org.videolan.libvlc.util.VLCVideoLayout
+import org.videolan.vlc.R
+
+/**
+ * Wrapper around [VLCVideoLayout] that adds an OpenGL pipeline on top of the
+ * classic VLC surfaces so that we can intercept decoded frames and post process
+ * them before displaying them to the user.
+ */
+class BeautyVideoLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : VLCVideoLayout(context, attrs, defStyleAttr) {
+
+    private val glSurfaceView: GLSurfaceView = GLSurfaceView(context)
+
+    init {
+        glSurfaceView.setEGLContextClientVersion(2)
+        glSurfaceView.preserveEGLContextOnPause = true
+        glSurfaceView.setZOrderMediaOverlay(true)
+        glSurfaceView.setBackgroundColor(0x00000000)
+        glSurfaceView.isClickable = false
+        glSurfaceView.isFocusable = false
+        addView(glSurfaceView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+    }
+
+    fun setRenderer(renderer: BeautyRenderer) {
+        glSurfaceView.setRenderer(renderer)
+        glSurfaceView.renderMode = GLSurfaceView.RENDERMODE_WHEN_DIRTY
+    }
+
+    fun queueEvent(action: () -> Unit) {
+        glSurfaceView.queueEvent(action)
+    }
+
+    fun requestRender() {
+        glSurfaceView.requestRender()
+    }
+
+    fun onRendererResume() {
+        glSurfaceView.onResume()
+    }
+
+    fun onRendererPause() {
+        glSurfaceView.onPause()
+    }
+
+    fun resetVideoSurfaceVisibility() {
+        findViewById<SurfaceView?>(R.id.surface_video)?.visibility = View.VISIBLE
+    }
+
+    fun getVideoSurfaceView(): SurfaceView? = findViewById(R.id.surface_video)
+
+    fun getSubtitleSurfaceView(): SurfaceView? = findViewById(R.id.surface_subtitles)
+}

--- a/application/vlc-android/src/org/videolan/vlc/gui/beauty/VideoBeautyDelegate.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/beauty/VideoBeautyDelegate.kt
@@ -1,0 +1,157 @@
+package org.videolan.vlc.gui.beauty
+
+import android.view.View
+import android.view.ViewStub
+import androidx.appcompat.widget.ViewStubCompat
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import com.google.android.material.slider.Slider
+import com.google.android.material.switchmaterial.SwitchMaterial
+import org.videolan.libvlc.MediaPlayer
+import org.videolan.libvlc.util.DisplayManager
+import org.videolan.vlc.R
+import org.videolan.vlc.gui.video.VideoPlayerActivity
+
+/**
+ * Lightweight controller that wires the beauty rendering pipeline with the UI
+ * controls exposed on the player overlay.
+ */
+class VideoBeautyDelegate(
+    private val activity: VideoPlayerActivity,
+    private val layout: BeautyVideoLayout?,
+    private val beautyStub: ViewStubCompat?
+) {
+
+    private val manager: BeautyManager? = layout?.let { BeautyManager(it) }
+
+    private var panelView: View? = null
+    private var switchMaterial: SwitchMaterial? = null
+    private var smoothingSlider: Slider? = null
+    private var faceSlider: Slider? = null
+    private var eyeSlider: Slider? = null
+    private var noseSlider: Slider? = null
+    private var mouthSlider: Slider? = null
+    private var filterIntensitySlider: Slider? = null
+    private var filterGroup: ChipGroup? = null
+
+    private var panelVisible = false
+
+    fun onResume() {
+        manager?.onResume()
+    }
+
+    fun onPause() {
+        manager?.onPause()
+    }
+
+    fun onDestroy() {
+        manager?.destroy()
+    }
+
+    fun detachFromPlayer() {
+        manager?.detachFromPlayer()
+    }
+
+    fun attachToPlayer(mediaPlayer: MediaPlayer, displayManager: DisplayManager) {
+        manager?.attachToPlayer(mediaPlayer, displayManager)
+    }
+
+    fun togglePanel() {
+        ensurePanel()?.let { panel ->
+            panelVisible = !panelVisible
+            panel.visibility = if (panelVisible) View.VISIBLE else View.GONE
+        }
+    }
+
+    fun hidePanel() {
+        panelVisible = false
+        panelView?.visibility = View.GONE
+    }
+
+    fun onOverlayVisibilityChanged(visible: Boolean) {
+        if (!visible) hidePanel()
+    }
+
+    private fun ensurePanel(): View? {
+        if (panelView == null) {
+            panelView = when (val stub = beautyStub) {
+                is ViewStub -> stub.inflate()
+                is ViewStubCompat -> stub.inflate()
+                else -> null
+            }
+            setupPanel(panelView)
+        }
+        return panelView
+    }
+
+    private fun setupPanel(panel: View?) {
+        if (panel == null || manager == null) return
+        switchMaterial = panel.findViewById(R.id.beauty_switch)
+        smoothingSlider = panel.findViewById(R.id.beauty_slider_smooth)
+        faceSlider = panel.findViewById(R.id.beauty_slider_face)
+        eyeSlider = panel.findViewById(R.id.beauty_slider_eye)
+        noseSlider = panel.findViewById(R.id.beauty_slider_nose)
+        mouthSlider = panel.findViewById(R.id.beauty_slider_mouth)
+        filterIntensitySlider = panel.findViewById(R.id.beauty_slider_filter_intensity)
+        filterGroup = panel.findViewById(R.id.beauty_filter_group)
+
+        val currentConfig = manager.currentConfig()
+
+        switchMaterial?.apply {
+            isChecked = true
+            setOnCheckedChangeListener { _, isChecked ->
+                manager.setBeautyEnabled(isChecked)
+            }
+        }
+
+        fun Slider.bind(initial: Float, onChange: (Float) -> Unit) {
+            valueFrom = 0f
+            valueTo = 1f
+            stepSize = 0.01f
+            value = initial
+            addOnChangeListener { _, value, fromUser ->
+                if (fromUser) onChange(value)
+            }
+        }
+
+        smoothingSlider?.bind(currentConfig.skinSmoothing) { value ->
+            manager.updateConfig { it.copy(skinSmoothing = value) }
+        }
+        faceSlider?.bind(currentConfig.faceSlimming) { value ->
+            manager.updateConfig { it.copy(faceSlimming = value) }
+        }
+        eyeSlider?.bind(currentConfig.eyeEnlarge) { value ->
+            manager.updateConfig { it.copy(eyeEnlarge = value) }
+        }
+        noseSlider?.bind(currentConfig.noseRefine) { value ->
+            manager.updateConfig { it.copy(noseRefine = value) }
+        }
+        mouthSlider?.bind(currentConfig.mouthAdjust) { value ->
+            manager.updateConfig { it.copy(mouthAdjust = value) }
+        }
+        filterIntensitySlider?.bind(currentConfig.filterIntensity) { value ->
+            manager.updateConfig { it.copy(filterIntensity = value) }
+        }
+
+        filterGroup?.apply {
+            isSingleSelection = true
+            val group = this
+            val currentId = manager.currentFilter().id
+            removeAllViews()
+            BeautyFilterPreset.presets().forEach { preset ->
+                val chip = Chip(activity).apply {
+                    text = activity.getString(preset.titleRes)
+                    isCheckable = true
+                    id = View.generateViewId()
+                    isChecked = preset.id == currentId
+                    setOnClickListener {
+                        group.check(this.id)
+                        manager.selectFilter(preset)
+                    }
+                }
+                addView(chip)
+                if (preset.id == currentId) check(chip.id)
+            }
+        }
+    }
+}

--- a/application/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerActivity.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerActivity.kt
@@ -79,6 +79,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.BaseContextWrappingDelegate
 import androidx.appcompat.widget.PopupMenu
+import androidx.appcompat.widget.ViewStubCompat
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.constraintlayout.widget.Guideline
@@ -184,6 +185,8 @@ import org.videolan.vlc.getSelectedVideoTrack
 import org.videolan.vlc.gui.DialogActivity
 import org.videolan.vlc.gui.audio.EqualizerFragment
 import org.videolan.vlc.gui.audio.PlaylistAdapter
+import org.videolan.vlc.gui.beauty.BeautyVideoLayout
+import org.videolan.vlc.gui.beauty.VideoBeautyDelegate
 import org.videolan.vlc.gui.browser.EXTRA_MRL
 import org.videolan.vlc.gui.dialogs.PlaybackSpeedDialog
 import org.videolan.vlc.gui.dialogs.RenderersDialog
@@ -300,6 +303,8 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
     private val playerKeyListenerDelegate: PlayerKeyListenerDelegate by lazy(LazyThreadSafetyMode.NONE) { PlayerKeyListenerDelegate(this@VideoPlayerActivity) }
     val tipsDelegate: VideoTipsDelegate by lazy(LazyThreadSafetyMode.NONE) { VideoTipsDelegate(this@VideoPlayerActivity) }
     var isTv: Boolean = false
+
+    private var beautyDelegate: VideoBeautyDelegate? = null
 
     private val dialogsDelegate = DialogDelegate()
     private var baseContextWrappingDelegate: AppCompatDelegate? = null
@@ -544,6 +549,10 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
         }
 
         videoLayout = findViewById(R.id.video_layout)
+        beautyDelegate = (videoLayout as? BeautyVideoLayout)?.let { beautyLayout ->
+            val stub = findViewById<ViewStubCompat?>(R.id.player_beauty_stub)
+            if (stub != null) VideoBeautyDelegate(this, beautyLayout, stub) else null
+        }
 
         /* Loading view */
         loadingImageView = findViewById(R.id.player_overlay_loading)
@@ -726,6 +735,7 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
     override fun onResume() {
         overridePendingTransition(0, 0)
         super.onResume()
+        beautyDelegate?.onResume()
         isShowingDialog = false
         waitingForPin = false
 
@@ -778,6 +788,7 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
         val finishing = isFinishing
         if (finishing)
             overridePendingTransition(0, 0)
+        beautyDelegate?.onPause()
         else
             overlayDelegate.hideOverlay(true)
         super.onPause()
@@ -999,6 +1010,7 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
 
     override fun onDestroy() {
         super.onDestroy()
+        beautyDelegate?.onDestroy()
         playlistModel?.run {
             dataset.removeObserver(playlistObserver)
             onCleared()
@@ -1028,6 +1040,7 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
             val mediaPlayer = mediaplayer
             if (!displayManager.isOnRenderer) videoLayout?.let {
                 mediaPlayer.attachViews(it, displayManager, true, false)
+                beautyDelegate?.attachToPlayer(mediaPlayer, displayManager)
                 val size = if (isBenchmark) MediaPlayer.ScaleType.SURFACE_FILL else MediaPlayer.ScaleType.values()[settings.getInt(VIDEO_RATIO, MediaPlayer.ScaleType.SURFACE_BEST_FIT.ordinal)]
                 mediaPlayer.videoScale = size
             }
@@ -1057,6 +1070,7 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
     private fun stopPlayback() {
         if (!playbackStarted) return
 
+        beautyDelegate?.detachFromPlayer()
         if (!displayManager.isPrimary && !isFinishing || service == null) {
             playbackStarted = false
             return
@@ -1161,6 +1175,7 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
         /* Stop listening for changes to media routes. */
         if (!isBenchmark) displayManager.removeMediaRouterCallback()
 
+        beautyDelegate?.detachFromPlayer()
         if (!displayManager.isSecondary) service?.mediaplayer?.detachViews()
     }
 
@@ -2059,6 +2074,14 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
     fun resizeVideo() = resizeDelegate.resizeVideo()
 
     fun displayResize() = resizeDelegate.displayResize()
+
+    fun toggleBeautyPanel() {
+        beautyDelegate?.togglePanel()
+    }
+
+    fun onOverlayVisibilityChanged(visible: Boolean) {
+        beautyDelegate?.onOverlayVisibilityChanged(visible)
+    }
 
     private fun showTitle() {
         if (isNavMenu) return

--- a/application/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerOverlayDelegate.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerOverlayDelegate.kt
@@ -432,6 +432,7 @@ class VideoPlayerOverlayDelegate (private val player: VideoPlayerActivity) {
             }
             if (!player.isShowing) {
                 player.isShowing = true
+                player.onOverlayVisibilityChanged(true)
                 if (!player.isLocked) {
                     showControls(true)
                 }
@@ -950,6 +951,7 @@ class VideoPlayerOverlayDelegate (private val player: VideoPlayerActivity) {
 
             showControls(false)
             player.isShowing = false
+            player.onOverlayVisibilityChanged(false)
             dimStatusBar(true)
             playlistSearchText.editText?.setText("")
         } else if (!fromUser) {


### PR DESCRIPTION
## Summary
- introduce a BeautyVideoLayout/OpenGL pipeline and manager to intercept VLC frames for beauty processing
- add delegate and UI overlays with sliders, filter chips, and toggle button to control beauty settings at runtime
- update player layouts/resources to host the panel and wire overlay visibility events

## Testing
- `./gradlew -p application/vlc-android assembleDebug` *(fails: Gradle wrapper not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ca66d8a7e8832aa72292a7f1c2cdd9